### PR TITLE
Fix platform comparison to pass on jshint

### DIFF
--- a/tasks/swf.js
+++ b/tasks/swf.js
@@ -29,7 +29,7 @@ module.exports = function (grunt) {
     var fs = require('fs');
     var pathUtil = require('path');
     var mxmlcPath = pathUtil.resolve(process.cwd(), sdkPath, './bin/mxmlc');
-    if (process.platform == 'win32') {
+    if (process.platform === 'win32') {
       // node does not appear to have a seperate flag for 64-bit windows: http://nodejs.org/api/process.html#process_process_platform
       mxmlcPath += ".bat";
     }


### PR DESCRIPTION
Issue description:
Running "jshint:all" (jshint) task

tasks/swf.js
  line 32  col 28  Expected '===' and instead saw '=='.

  ‼  1 warning

Warning: Task "jshint:all" failed. Use --force to continue.
